### PR TITLE
Autoregister all users

### DIFF
--- a/configs/module.ini
+++ b/configs/module.ini
@@ -12,4 +12,4 @@ dependencies = api
 ; generated unique identifier
 uuid = ""
 ; semantic version number (>= "1.0.0")
-version = "1.0.0"
+version = "1.1.0"

--- a/database/upgrade/1.1.0.php
+++ b/database/upgrade/1.1.0.php
@@ -1,0 +1,53 @@
+<?php
+/*=========================================================================
+ Midas Server
+ Copyright Kitware SAS, 26 rue Louis Guérin, 69100 Villeurbanne, France.
+ All rights reserved.
+ For more information visit http://www.kitware.com/.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0.txt
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+=========================================================================*/
+
+/** Upgrade the autoregister module to version 1.1.0. */
+class Autoregister_Upgrade_1_1_0 extends MIDASUpgrade
+{
+    /** @var string */
+    public $moduleName = 'autoregister';
+
+    /** Post database upgrade. */
+    public function postUpgrade()
+    {
+        // load all the autoregistered communities
+        $targetedcommunityModel = MidasLoader::loadModel('Targetedcommunity', 'autoregister');
+        $communities = $targetedcommunityModel->getAllTargeted();
+        $groupModel = MidasLoader::loadModel('Group');
+        $userModel = MidasLoader::loadModel('User');
+        foreach ($communities as $community) {
+            $memberGroup = $community->getMemberGroup();
+            // register all users to all autoregistered communities
+            $limit = 50;
+            $offset = 0;
+            while(true) {
+                $users = $userModel->getAll(false, $limit, 'lastname', $offset);
+                foreach ($users as $user) {
+                    $groupModel->addUser($memberGroup, $user);
+                }
+                if (count($users) < $limit) {
+                    break;
+                } else {
+                    $offset = $offset + $limit;
+                }
+            }
+        }
+    }
+}

--- a/models/base/TargetedcommunityModelBase.php
+++ b/models/base/TargetedcommunityModelBase.php
@@ -48,10 +48,19 @@ abstract class Autoregister_TargetedcommunityModelBase extends Autoregister_AppM
         // now add all users as members
         $groupModel = MidasLoader::loadModel('Group');
         $userModel = MidasLoader::loadModel('User');
-        $users = $userModel->getAll();
         $memberGroup = $community->getMemberGroup();
-        foreach ($users as $user) {
-            $groupModel->addUser($memberGroup, $user);
+        $limit = 50;
+        $offset = 0;
+        while(true) {
+            $users = $userModel->getAll(false, $limit, 'lastname', $offset);
+            foreach ($users as $user) {
+                $groupModel->addUser($memberGroup, $user);
+            }
+            if (count($users) < $limit) {
+                break;
+            } else {
+                $offset = $offset + $limit;
+            }
         }
      } else {
         $targetedcommunity = $targetedcommunities[0];

--- a/models/pdo/TargetedcommunityModel.php
+++ b/models/pdo/TargetedcommunityModel.php
@@ -39,7 +39,6 @@ class Autoregister_TargetedcommunityModel extends Autoregister_Targetedcommunity
 
     /** gets all communities that aren't in the autoregister targeted list */
     public function getAllIgnored() {
-        $select = "select * from community where community_id not in (select community_id from autoregister_targetedcommunity";
         $communityModel = MidasLoader::loadModel('Community');
         $communities = $communityModel->getAll();
         $targeted = $this->getAllTargeted();


### PR DESCRIPTION
Fixes #3 .

This fix will ensure that all users are added to an autoregister community when a community is targeted as an autoregister community.

When the plugin is upgraded, it will autoregister all users to any current autoregister community.
