### PR TITLE
Fix upgrade to 1.0.1.

### DIFF
--- a/configs/module.ini
+++ b/configs/module.ini
@@ -12,4 +12,4 @@ dependencies = api
 ; generated unique identifier
 uuid = ""
 ; semantic version number (>= "1.0.0")
-version = "1.1.0"
+version = "1.0.1"

--- a/database/mysql/1.0.1.sql
+++ b/database/mysql/1.0.1.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS `autoregister_targetedcommunity` (
+    `targetedcommunity_id` bigint(20) NOT NULL AUTO_INCREMENT,
+    `community_id` bigint(20) NOT NULL,
+    `creation_date` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (`targetedcommunity_id`)
+) DEFAULT CHARSET=utf8;

--- a/database/upgrade/1.0.1.php
+++ b/database/upgrade/1.0.1.php
@@ -18,8 +18,8 @@
  limitations under the License.
 =========================================================================*/
 
-/** Upgrade the autoregister module to version 1.1.0. */
-class Autoregister_Upgrade_1_1_0 extends MIDASUpgrade
+/** Upgrade the autoregister module to version 1.0.1. */
+class Autoregister_Upgrade_1_0_1 extends MIDASUpgrade
 {
     /** @var string */
     public $moduleName = 'autoregister';


### PR DESCRIPTION
The previous upgrade should have gone from 1.0.0 to 1.0.1, but instead
went to 1.1.0.  To property semantic version, this should be an upgrade
to 1.0.1.  Additionally, there is a new requirement in Midas that each
version of a module provide a full database install script for the
plugin at that version state, so this has been added.  This should fix
the problem where the module could have been upgraded before but not
installed and upgraded in one go.  Now the module will install correctly
at version 1.0.1
